### PR TITLE
Improve/fix du and cp commands for non-Linux platforms

### DIFF
--- a/volume/driver/naive.go
+++ b/volume/driver/naive.go
@@ -1,10 +1,7 @@
 package driver
 
 import (
-	"bytes"
-	"fmt"
 	"os"
-	"os/exec"
 )
 
 type NaiveDriver struct{}
@@ -17,25 +14,3 @@ func (driver *NaiveDriver) DestroyVolume(path string) error {
 	return os.RemoveAll(path)
 }
 
-func (driver *NaiveDriver) CreateCopyOnWriteLayer(path string, parent string) error {
-	return exec.Command("cp", "-r", parent, path).Run()
-}
-
-func (driver *NaiveDriver) GetVolumeSizeInBytes(path string) (int64, error) {
-	stdout := &bytes.Buffer{}
-	cmd := exec.Command("du", path)
-	cmd.Stdout = stdout
-
-	err := cmd.Run()
-	if err != nil {
-		return 0, err
-	}
-
-	var size int64
-	_, err = fmt.Sscanf(stdout.String(), "%d", &size)
-	if err != nil {
-		return 0, err
-	}
-
-	return size, nil
-}

--- a/volume/driver/naive_stub.go
+++ b/volume/driver/naive_stub.go
@@ -1,0 +1,32 @@
+// +build !windows
+
+package driver
+
+import (
+	"bytes"
+	"fmt"
+	"os/exec"
+)
+
+func (driver *NaiveDriver) CreateCopyOnWriteLayer(path string, parent string) error {
+	return exec.Command("cp", "-r", parent, path).Run()
+}
+
+func (driver *NaiveDriver) GetVolumeSizeInBytes(path string) (int64, error) {
+	stdout := &bytes.Buffer{}
+	cmd := exec.Command("du", "-sk", path)
+	cmd.Stdout = stdout
+
+	err := cmd.Run()
+	if err != nil {
+		return 0, err
+	}
+
+	var size int64
+	_, err = fmt.Sscanf(stdout.String(), "%d", &size)
+	if err != nil {
+		return 0, err
+	}
+
+	return size * 512, nil
+}

--- a/volume/driver/naive_stub.go
+++ b/volume/driver/naive_stub.go
@@ -14,7 +14,7 @@ func (driver *NaiveDriver) CreateCopyOnWriteLayer(path string, parent string) er
 
 func (driver *NaiveDriver) GetVolumeSizeInBytes(path string) (int64, error) {
 	stdout := &bytes.Buffer{}
-	cmd := exec.Command("du", "-sk", path)
+	cmd := exec.Command("du", "-s", path)
 	cmd.Stdout = stdout
 
 	err := cmd.Run()

--- a/volume/driver/naive_windows.go
+++ b/volume/driver/naive_windows.go
@@ -1,0 +1,62 @@
+package driver
+
+import (
+	"bytes"
+	"os/exec"
+	"errors"
+	"strconv"
+	"syscall"
+	"regexp"
+)
+
+func (driver *NaiveDriver) CreateCopyOnWriteLayer(path string, parent string) error {
+	_, err := robocopy("/e", "/nfl", "/ndl", parent, path)
+	return err
+}
+
+func (driver *NaiveDriver) GetVolumeSizeInBytes(path string) (int64, error) {
+	re := regexp.MustCompile("Bytes :\\s*(\\d*)")
+	stdout, err := robocopy("/l", "/nfl", "/ndl", path, "\\\\localhost\\C$\\nul", "/e", "/bytes")
+
+	if err != nil {
+		return 0, err
+	}
+
+	matches := re.FindStringSubmatch(stdout)
+
+	if matches != nil {
+		size, err := strconv.ParseInt(matches[1], 10, 64)
+		if err != nil {
+			return 0, err
+		}
+		return size, nil
+	}
+	return 0, errors.New("Unable to extract size from robocopy output")
+}
+
+func robocopy(args ...string) (string, error) {
+	stdout := &bytes.Buffer{}
+
+	cmd := exec.Command("robocopy", args...)
+	cmd.Stdout = stdout
+
+	if err := cmd.Start(); err != nil {
+		return "", err
+	}
+
+	// Robocopy returns a status code indicating what action occurred. 0 means nothing was copied,
+	// 1 means that files were copied successfully. Google for additional error codes.
+	if err := cmd.Wait(); err != nil {
+		if exiterr, ok := err.(*exec.ExitError); ok {
+			if status, ok := exiterr.Sys().(syscall.WaitStatus); ok {
+				if status.ExitStatus() > 1 {
+					return "", err
+				}
+			}
+		} else {
+			return "", err
+		}
+	}
+
+	return stdout.String(), nil
+}


### PR DESCRIPTION
- On Windows, robocopy is much more performant at copying things around
  and can also be used as a 'du' replacement. Now also there is less
  need for cygwin/Gnuwin frameworks.
- The way du was being called was generally also broken.