### PR TITLE
Prevent UID translator from changing perms outside volume

### DIFF
--- a/uidgid/translator.go
+++ b/uidgid/translator.go
@@ -39,7 +39,9 @@ func (t *translator) TranslatePath(path string, info os.FileInfo, err error) err
 	if touid != uid || togid != gid {
 		mode := info.Mode()
 		t.chown(path, touid, togid)
-		t.chmod(path, mode)
+		if mode&os.ModeSymlink == 0 {
+			t.chmod(path, mode)
+		}
 	}
 
 	return nil


### PR DESCRIPTION
When a volume had a symlink, the symlink would be resolved outside the
volume during UID/GID translation. The os.Walk used during translation
would call Lstat on each object, and this is what is used during
translation. This means that the Mode() would be for the symlink itself
(which is 777). However, the chmod call would act through the symlink,
changing the permissions on the underlying object.

This meant that any symlink in the volume would result in a chmod 0777
call directed at a file on the host system itself, allowing a hostile
volume to change permissions on important system files (/usr/bin,
/etc/passwd, etc) by creating those files.

The most correct fix here would be a lchmod call, but that doesn't exist
because POSIX assumes symlinks don't have independent permissions (and
so are always 0777). This means this fix should be correct on platforms
for which this assumption holds; however, this assumption does not hold
on OSX. I am unaware of any high-level go API that solves that problem,
which means a more nuanced fix here would require a direct syscall on
OSX (see https://github.com/golang/go/issues/20130 for some discussion).

concourse/concourse#1736