### PR TITLE
baggageclaimcmd: fix build issues on 32bit platforms

### DIFF
--- a/baggageclaimcmd/driver_linux.go
+++ b/baggageclaimcmd/driver_linux.go
@@ -51,7 +51,7 @@ func (cmd *BaggageclaimCommand) driver(logger lager.Logger) (volume.Driver, erro
 
 	volumesDir := cmd.VolumesDir.Path()
 
-	if cmd.Driver == "btrfs" && fsStat.Type != btrfsFSType {
+	if cmd.Driver == "btrfs" && uint32(fsStat.Type) != btrfsFSType {
 		volumesImage := volumesDir + ".img"
 		filesystem := fs.New(logger.Session("fs"), volumesImage, volumesDir, cmd.MkfsBin)
 


### PR DESCRIPTION
fsStat.Type is `int32` on 32bit platforms and 0x9123683e overflows it.