### PR TITLE
ci: ensure required Windows binaries are on PATH

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@ _testmain.go
 *.exe
 *.test
 *.prof
+tags

--- a/ci/scripts/unit-windows.bat
+++ b/ci/scripts/unit-windows.bat
@@ -1,4 +1,4 @@
-set PATH=C:\Go\bin;C:\Program Files\Git\cmd;%PATH%
+set PATH=C:\Go\bin;C:\Program Files\Git\cmd;C:\ProgramData\chocolatey\lib\mingw\tools\install\mingw64\bin;C:\Program Files (x86)\Windows Resource Kits\Tools;%PATH%
 
 set GOPATH=%CD%\gopath
 set PATH=%CD%\gopath\bin;%PATH%


### PR DESCRIPTION
related to concourse/ci#221

gcc is required to build Datadog/zstd and robocopy is required for baggageclaim
to work.