### PR TITLE
add image-building to pipeline

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,4 +22,5 @@ _testmain.go
 *.exe
 *.test
 *.prof
+
 tags

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,17 +1,6 @@
 FROM golang:1
 
-RUN apt-get update && \
-    apt-get -y install \
-        file \
-        liblzo2-dev \
-        libblkid-dev \
-        e2fslibs-dev \
-        pkg-config \
-        libz-dev \
-        libzstd-dev && \
-    cd /tmp && \
-    curl -L https://www.kernel.org/pub/linux/kernel/people/kdave/btrfs-progs/btrfs-progs-v4.15.tar.gz | tar zxf - && \
-    cd btrfs-progs-* && \
-    ./configure --disable-documentation && \
-    make && \
-    make install
+RUN apt-get update -qq && \
+    apt-get install -yqq \
+          file \
+          btrfs-progs

--- a/ci/build-image.yml
+++ b/ci/build-image.yml
@@ -1,0 +1,11 @@
+platform: linux
+params:
+  CONTEXT: baggageclaim-dockerfile
+inputs:
+- name: baggageclaim-dockerfile
+outputs:
+- name: image
+caches:
+- path: cache
+run:
+  path: build

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -40,6 +40,7 @@ resources:
   source:
     uri: https://github.com/concourse/baggageclaim.git
     branch: master
+  icon: &git-icon github-circle
 - name: baggageclaim-image-building
   type: git
   source:
@@ -48,17 +49,20 @@ resources:
     paths:
     - Dockerfile
     - ci/build-image.yml
+  icon: *git-icon
 - name: baggageclaim-ci-image
   type: registry-image
   source:
     repository: concourse/baggageclaim-ci
     password: ((docker.password))
     username: ((docker.username))
+  icon: docker
 - name: golang-1.x
   type: registry-image
   source:
     repository: golang
     tag: 1
+  icon: language-go
 - name: oci-build-task
   type: registry-image
   icon: docker

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -4,16 +4,15 @@ jobs:
   public: true
   plan:
   - in_parallel:
-    - get: baggageclaim-dockerfile
+    - get: baggageclaim-image-building
       trigger: true
     - get: golang-1.x
       trigger: true
-    - get: baggageclaim
     - get: oci-build-task
   - task: build
     image: oci-build-task
     privileged: true
-    file: baggageclaim/ci/build-image.yml
+    file: baggageclaim-image-building/ci/build-image.yml
   - put: baggageclaim-ci-image
     params: {image: image/image.tar}
 - name: baggageclaim
@@ -40,13 +39,15 @@ resources:
   type: git
   source:
     uri: https://github.com/concourse/baggageclaim.git
-    branch: add-image-building
-- name: baggageclaim-dockerfile
+    branch: master
+- name: baggageclaim-image-building
   type: git
   source:
     uri: https://github.com/concourse/baggageclaim.git
-    branch: add-image-building
-    paths: [Dockerfile]
+    branch: master
+    paths:
+    - Dockerfile
+    - ci/build-image.yml
 - name: baggageclaim-ci-image
   type: registry-image
   source:

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -1,13 +1,33 @@
 ---
 jobs:
+- name: build-image
+  public: true
+  plan:
+  - in_parallel:
+    - get: baggageclaim-dockerfile
+      trigger: true
+    - get: golang-1.x
+      trigger: true
+    - get: baggageclaim
+    - get: oci-build-task
+  - task: build
+    image: oci-build-task
+    privileged: true
+    file: baggageclaim/ci/build-image.yml
+  - put: baggageclaim-ci-image
+    params: {image: image/image.tar}
 - name: baggageclaim
   public: true
   serial: true
   plan:
-  - get: baggageclaim
-    trigger: true
-  - aggregate:
+  - in_parallel:
+    - get: baggageclaim
+      trigger: true
+    - get: baggageclaim-ci-image
+      passed: [build-image]
+  - in_parallel:
     - task: unit-linux
+      image: baggageclaim-ci-image
       privileged: true
       file: baggageclaim/ci/unit-linux.yml
     - task: unit-darwin
@@ -20,4 +40,25 @@ resources:
   type: git
   source:
     uri: https://github.com/concourse/baggageclaim.git
-    branch: master
+    branch: add-image-building
+- name: baggageclaim-dockerfile
+  type: git
+  source:
+    uri: https://github.com/concourse/baggageclaim.git
+    branch: add-image-building
+    paths: [Dockerfile]
+- name: baggageclaim-ci-image
+  type: registry-image
+  source:
+    repository: concourse/baggageclaim-ci
+    password: ((docker.password))
+    username: ((docker.username))
+- name: golang-1.x
+  type: registry-image
+  source:
+    repository: golang
+    tag: 1
+- name: oci-build-task
+  type: registry-image
+  icon: docker
+  source: {repository: vito/oci-build-task}

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -1,4 +1,9 @@
 ---
+resource_types:
+- name: slack-notifier
+  type: registry-image
+  source: {repository: mockersf/concourse-slack-notifier}
+
 jobs:
 - name: build-image
   public: true
@@ -8,6 +13,7 @@ jobs:
       trigger: true
     - get: golang-1.x
       trigger: true
+    - get: ci
     - get: oci-build-task
   - task: build
     image: oci-build-task
@@ -15,6 +21,20 @@ jobs:
     file: baggageclaim-image-building/ci/build-image.yml
   - put: baggageclaim-ci-image
     params: {image: image/image.tar}
+  on_failure:
+    do:
+    - task: format-slack-message
+      file: ci/tasks/format-slack-message.yml
+      input_mapping: {src: baggageclaim-image-building}
+      params:
+        GITHUB_TOKEN: ((concourse_github_dummy.access_token))
+        SLACK_TOKEN: ((slack_token))
+        GITHUB_REPO: baggageclaim
+    - put: notify
+      params:
+        message_file: message/message
+        mode: normal
+        alert_type: failed
 - name: baggageclaim
   public: true
   serial: true
@@ -24,6 +44,7 @@ jobs:
       trigger: true
     - get: baggageclaim-ci-image
       passed: [build-image]
+    - get: ci
   - in_parallel:
     - task: unit-linux
       image: baggageclaim-ci-image
@@ -33,6 +54,20 @@ jobs:
       file: baggageclaim/ci/unit-darwin.yml
     - task: unit-windows
       file: baggageclaim/ci/unit-windows.yml
+  on_failure:
+    do:
+    - task: format-slack-message
+      file: ci/tasks/format-slack-message.yml
+      input_mapping: {src: baggageclaim}
+      params:
+        GITHUB_TOKEN: ((concourse_github_dummy.access_token))
+        SLACK_TOKEN: ((slack_token))
+        GITHUB_REPO: baggageclaim
+    - put: notify
+      params:
+        message_file: message/message
+        mode: normal
+        alert_type: failed
 
 resources:
 - name: baggageclaim
@@ -50,6 +85,12 @@ resources:
     - Dockerfile
     - ci/build-image.yml
   icon: *git-icon
+- name: ci
+  type: git
+  icon: *git-icon
+  source:
+    uri: https://github.com/concourse/ci.git
+    branch: master
 - name: baggageclaim-ci-image
   type: registry-image
   source:
@@ -67,3 +108,8 @@ resources:
   type: registry-image
   icon: docker
   source: {repository: vito/oci-build-task}
+- name: notify
+  type: slack-notifier
+  icon: slack
+  source:
+    url: ((slack_hook))

--- a/ci/unit-linux.yml
+++ b/ci/unit-linux.yml
@@ -1,11 +1,6 @@
 ---
 platform: linux
 
-image_resource:
-  type: registry-image
-  source:
-    repository: concourse/baggageclaim-ci
-
 inputs:
 - name: baggageclaim
 


### PR DESCRIPTION
related to concourse/ci#221

I'm not sure what the reason for building btrfs-progs from source was originally, but the tests seem to work fine if we just use the existing apt package in debian buster/`go:1`. So a side effect of this PR is that we're now testing against btrfs-progs v4.20 instead of v4.15.

EDIT: blocked on concourse/ci#230