### PR TITLE
fix nesting volumes even more deeply

### DIFF
--- a/volume/driver/overlay_linux.go
+++ b/volume/driver/overlay_linux.go
@@ -69,8 +69,8 @@ func (driver *OverlayDriver) CreateCopyOnWriteLayer(
 		return err
 	}
 
-	childDir := driver.layerDir(child)
 	if hasGrandparent {
+		childDir := driver.layerDir(child)
 		parentDir := driver.layerDir(parent)
 		err := copy.Cp(false, parentDir, childDir)
 		if err != nil {
@@ -78,6 +78,20 @@ func (driver *OverlayDriver) CreateCopyOnWriteLayer(
 		}
 
 		parent = grandparent
+
+		// resolve to root volume
+		for {
+			grandparent, hasGrandparent, err := parent.Parent()
+			if err != nil {
+				return err
+			}
+
+			if !hasGrandparent {
+				break
+			}
+
+			parent = grandparent
+		}
 	}
 
 	return driver.overlayMount(child, parent)


### PR DESCRIPTION
the previous fix actually only made it work slightly more deeply; this
should fix it all the way. the problem was that the grandparent was
found using its logical parent, rather than the 'actual' parent, which
must be found by recursively walking through the hierarchy all the way
to the bottom.

* test up to depth 10
* assert that file updates and deletions are preserved at each depth,
  just to be sure

Signed-off-by: Alex Suraci <suraci.alex@gmail.com>