### PR TITLE
Change device regex if testing on windows

### DIFF
--- a/api/p2p_server_test.go
+++ b/api/p2p_server_test.go
@@ -1,19 +1,21 @@
 package api_test
 
 import (
+	"net/http"
+	"net/http/httptest"
+	"regexp"
+	"runtime"
+
 	"code.cloudfoundry.org/lager/lagertest"
 	"github.com/concourse/baggageclaim/api"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-	"net/http"
-	"net/http/httptest"
-	"regexp"
 )
 
 var _ = Describe("P2P Server", func() {
 	var (
 		handler http.Handler
-		infc string
+		infc    string
 	)
 
 	JustBeforeEach(func() {
@@ -26,10 +28,10 @@ var _ = Describe("P2P Server", func() {
 
 	Describe("get p2p url", func() {
 		var (
-			request *http.Request
+			request  *http.Request
 			recorder *httptest.ResponseRecorder
 		)
-		JustBeforeEach(func(){
+		JustBeforeEach(func() {
 			var err error
 			request, err = http.NewRequest("GET", "/p2p-url", nil)
 			Expect(err).NotTo(HaveOccurred())
@@ -38,9 +40,12 @@ var _ = Describe("P2P Server", func() {
 			handler.ServeHTTP(recorder, request)
 		})
 
-		Context("when a valid interface name is given", func(){
-			BeforeEach(func(){
+		Context("when a valid interface name is given", func() {
+			BeforeEach(func() {
 				infc = "lo"
+				if runtime.GOOS == "windows" {
+					infc = "Loopback"
+				}
 			})
 
 			It("returns a url successfully", func() {
@@ -49,8 +54,8 @@ var _ = Describe("P2P Server", func() {
 			})
 		})
 
-		Context("when an invalid interface name is given", func(){
-			BeforeEach(func(){
+		Context("when an invalid interface name is given", func() {
+			BeforeEach(func() {
 				infc = "dummy_interface"
 			})
 


### PR DESCRIPTION
No need to release a new version of baggageclaim, this was only a problem with the test on windows.

**The change is on line 46-48**

The file got formatted and I decided to keep it in the commit.

Windows network device names are very different from unix systems.

On unix you'll get a list like this:
```
lo0
gif0
stf0
en0
en1
en2
```

On Windows you'll get this:
```
Ethernet 4
Local Area Connection* 2
Local Area Connection* 12
Wi-Fi 5
Bluetooth Network Connection 2
Loopback Pseudo-Interface 1
vEthernet (Default Switch)
```

You can't even use a simple regex like `lo` that the test was using
because you could end up matching against the "Local Area..." devices
instead for the test (this may be what you want in the real world
though).