### PR TITLE
Enable metacopy for overlay driver

### DIFF
--- a/volume/driver/overlay_linux.go
+++ b/volume/driver/overlay_linux.go
@@ -1,6 +1,7 @@
 package driver
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -25,7 +26,10 @@ func init() {
 // when they are written to.
 func metacopySupported() bool {
 	_, err := os.Stat("/sys/module/overlay/parameters/metacopy")
-	return !os.IsNotExist(err)
+	if err != nil {
+		return !errors.Is(err, os.ErrNotExist)
+	}
+	return true
 }
 
 type OverlayDriver struct {


### PR DESCRIPTION
Closes concourse/concourse#6620
Is only enabled if the kernel supports the feature. Metacopy was added
in kernel 4.19.

cc @muntac 